### PR TITLE
comma-dangle 과 space-before-function-paren 룰을 off 합니다.

### DIFF
--- a/rules/style.js
+++ b/rules/style.js
@@ -1,22 +1,3 @@
 module.exports = {
-  rules: {
-    'comma-dangle': [
-      'error',
-      {
-        arrays: 'always-multiline',
-        objects: 'always-multiline',
-        imports: 'never',
-        exports: 'never',
-        functions: 'always-multiline',
-      },
-    ],
-    'space-before-function-paren': [
-      'error',
-      {
-        anonymous: 'never',
-        named: 'never',
-        asyncArrow: 'always',
-      },
-    ],
-  },
+  rules: {},
 }


### PR DESCRIPTION
- `comma-dangle` 과 `space-before-function-paren` 이 prettier 와 충돌합니다.
  - lazy import ( `import('some-long-named-module')` ) 시 줄바꿈이 될 경우 trailing comma 를 추가하지만, prettier 에서는 이를 제거하도록 합니다. (from @appear tna-v2)
  - prettier 의 rule 을 따르도록 off 해둡니다.
