### PR TITLE
[#37] js 와 ts 모두 camelcase rule 을 통일합니다.

### DIFF
--- a/rules/style.js
+++ b/rules/style.js
@@ -1,3 +1,5 @@
 module.exports = {
-  rules: {},
+  rules: {
+    camelcase: ['error', { properties: 'always' }],
+  },
 }

--- a/rules/typescript.js
+++ b/rules/typescript.js
@@ -14,5 +14,7 @@ module.exports = {
       'error',
       { functions: false, classes: true },
     ],
+    camelcase: 'off',
+    '@typescript-eslint/camelcase': ['error', { properties: 'always' }],
   },
 }

--- a/test/javascript/objects.js
+++ b/test/javascript/objects.js
@@ -1,0 +1,4 @@
+export default {
+  // ok_hand: 1,
+  okHand: 2,
+}

--- a/test/typescript/objects.ts
+++ b/test/typescript/objects.ts
@@ -1,0 +1,4 @@
+export default {
+  // ok_hand: 1,
+  okHand: 2,
+}


### PR DESCRIPTION
### This closes #37 
`['error', { properties: 'always' }]` 로 통일합니다.

