### PR TITLE
curly:all rule을 반영합니다.

### DIFF
--- a/rules/style.js
+++ b/rules/style.js
@@ -1,7 +1,7 @@
 module.exports = {
   rules: {
     camelcase: ['error', { properties: 'always' }],
-    curly: ['error'],
+    curly: ['error', 'all'],
     'import/order': ['error',  {
       groups: ["builtin", "external", ["parent", "sibling", "index"]],
       'newlines-between': 'always'

--- a/test/typescript/src/components/ad-banner.tsx
+++ b/test/typescript/src/components/ad-banner.tsx
@@ -18,7 +18,9 @@ export default function AdBanner({ banners = [] }: AdBannerProps) {
   const [data, setData] = useState(banners)
 
   useEffect(() => {
-    if (banners.length) return
+    if (banners.length) {
+      return
+    }
 
     fetchAdBanners().then((fetchedBanners) => {
       setData(fetchedBanners)


### PR DESCRIPTION
#42 에서 나온 이슈로, single line으로 해결 가능한 if else phrase도 무조건 `{}` curly brace를 붙입니다.

resolved #42 