### PR TITLE
[GHA] pr comment 로 canary publish 했을때 발생하는 오류 수정

### DIFF
--- a/.github/workflows/canary.yaml
+++ b/.github/workflows/canary.yaml
@@ -26,7 +26,6 @@ jobs:
       SLACK_GITHUB_EVENT_NAME: "${{ github.event_name }}"
       SLACK_GITHUB_REPOSITORY: ${{ github.repository }}
       SLACK_DETAIL_URL: "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
       - name: Use Node.js ${{ matrix.node-version }}
@@ -37,7 +36,8 @@ jobs:
 
       - name: Recognize head sha of pull request
         env:
-          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           npx @titicaca/gha-tools pr=${{ github.event.issue.number }}
 


### PR DESCRIPTION
- pr 내용을 가져오기 위해 필요한 `GITHUB_TOKEN` 이 누락되어 추가해줍니다.
