### PR TITLE
🛠 eslint 환경에 jest 추가

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@ module.exports = {
   env: {
     node: true,
     browser: true,
+    jest: true,
   },
   parserOptions: {
     ecmaVersion: 2019,

--- a/typescript.js
+++ b/typescript.js
@@ -10,6 +10,7 @@ module.exports = {
   env: {
     node: true,
     browser: true,
+    jest: true,
   },
   parserOptions: {
     ecmaVersion: 2019,


### PR DESCRIPTION
## 설명
eslint 가 테스트 환경을 자동으로 인식하지 않아 `describe`, `it`, `except` 등을 인식하지 못해 경고를 표시하는데 이 부분을 해결하기 위해서 jest 환경값을 추가합니다.

linked: https://github.com/titicacadev/triple-genie-web/pull/408

## 테스트

create-triple-app 에 jest 테스팅 환경(https://github.com/titicacadev/create-triple-app/pull/117) 추가하면서 테스트 확인하였습니다. 