### PR TITLE
🔧 npm 패키지에 들어가는 파일 목록 명시

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,14 @@
   "version": "2.3.0",
   "description": "Triple's ESLint config, following our styleguide",
   "main": "index.js",
+  "files": [
+    "recommends",
+    "rules",
+    "index.js",
+    "prettierrc.js",
+    "stylelint.js",
+    "typescript.js"
+  ],
   "scripts": {
     "lint:es": "eslint './recommends/**/*.js' './rules/**/*.js'",
     "lint:es:fix": "npm run lint:es -- --fix",


### PR DESCRIPTION
패키지를 사용할 때 필요하지 않은 파일을 제외하여 패키지 전체 용량을 27.1kB에서 10.7kB로 줄입니다.

요것까지 하고 새 버전 릴리즈 해보겠습니당