### PR TITLE
예상치 못하게 높은 버전의 prettier가 설치되는 문제 수정

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "eslint-plugin-react": "^7.24.0",
         "eslint-plugin-react-hooks": "^4.2.0",
         "eslint-plugin-standard": "^4.0.1",
-        "prettier": "2.0",
+        "prettier": "2.0.5",
         "stylelint": "^13.6.1",
         "stylelint-config-recommended": "^3.0.0",
         "stylelint-config-styled-components": "^0.1.1",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "eslint-plugin-react": "^7.24.0",
     "eslint-plugin-react-hooks": "^4.2.0",
     "eslint-plugin-standard": "^4.0.1",
-    "prettier": "2.0",
+    "prettier": "2.0.5",
     "stylelint": "^13.6.1",
     "stylelint-config-recommended": "^3.0.0",
     "stylelint-config-styled-components": "^0.1.1",


### PR DESCRIPTION
버전을 고정하지 않으면 패키지를 설치하는 과정에서 의도한 버전보다 높은 버전의 prettier가 설치되고,
이는 예상치 못한 lint 오류를 일으킵니다.
이를 방지하기 위해 버전을 고정합니다.

https://prettier.io/blog/2021/05/09/2.3.0.html
prettier 공식 블로그에서도 버전을 고정하는 것을 추천했습니다.

---