### PR TITLE
💚 npm publish할 때 husky 비활성화

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -95,8 +95,7 @@ jobs:
         run: npx @titicaca/gha-tools notify
 
       - name: Publish to npm
-        run: |
-          PREPARE_HUSKY_DISABLED=true npm publish
+        run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.READ_WRITE_NPM_TOKEN }}
 

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "update-snapshot": "jest -u",
     "test:watch": "jest --watch",
     "test": "jest",
-    "prepare": "[ $PREPARE_HUSKY_DISABLED ] || husky install"
+    "prepare": "[ $CI ] || husky install"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
prepare 스크립트에서 husky 초기화 작업을 수행하는데, 이 스크립트가 npm publish 전에도 작동하는 스크립트입니다. 불필요한 husky 실행을 막는 환경 변수를 켜고 npm publish를 수행합니다.