### PR TITLE
충돌하는 규칙을 수정합니다.

### DIFF
--- a/rules/base.js
+++ b/rules/base.js
@@ -1,5 +1,7 @@
 module.exports = {
-  extends: ['./react', './react-hooks', './import'].map(require.resolve),
+  extends: ['./react', './react-hooks', './import', './promise'].map(
+    require.resolve,
+  ),
   rules: {
     /**
      * https://github.com/titicacadev/eslint-config-triple/issues/37

--- a/rules/promise.js
+++ b/rules/promise.js
@@ -1,0 +1,5 @@
+module.exports = {
+  rules: {
+    'promise/catch-or-return': ['error', { allowFinally: true }],
+  },
+}

--- a/test/__snapshots__/config.test.js.snap
+++ b/test/__snapshots__/config.test.js.snap
@@ -1151,6 +1151,9 @@ Object {
     ],
     "promise/catch-or-return": Array [
       "error",
+      Object {
+        "allowFinally": true,
+      },
     ],
     "promise/no-callback-in-promise": Array [
       "warn",
@@ -3072,6 +3075,9 @@ Object {
     ],
     "promise/catch-or-return": Array [
       "error",
+      Object {
+        "allowFinally": true,
+      },
     ],
     "promise/no-callback-in-promise": Array [
       "warn",


### PR DESCRIPTION
## 변경 내역

### `no-void` 규칙을 완화하여 비동기 함수를 호출할 때 void를 사용할 수 있게 처리합니다.

비동기 함수 호출만 하고 끝나는 코드에서 [`typescript-eslint/no-floating-promises`](https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-floating-promises.md
) 규칙을 지키지 않았다는 오류가 발생합니다.
이를 고치려면 함수 호출에 void를 붙일 수 있어야 하는데, [`no-void`](https://eslint.org/docs/rules/no-void) 규칙이 강하게 걸려 있어 붙일 수 없었습니다.
`no-void` 규칙에 statement에서 사용할 수 있게 해주는 옵션을 켜서 충돌을 해결합니다.

### catch를 사용하고 finally를 사용했을 때 오류가 없도록 규칙을 완화합니다.

[`promise/catch-or-return`](https://github.com/xjamundx/eslint-plugin-promise/blob/development/docs/rules/catch-or-return.md) 규칙이 `.catch`를 사용하고 `.finally`를 사용했을 때 오류가 발생합니다. 일반적인 경우라고 생각해서 finally는 완화하는 옵션을 사용합니다.