### PR TITLE
타입 체크 규칙을 사용할 수 있는 옵션 추가

### DIFF
--- a/create-config.js
+++ b/create-config.js
@@ -3,7 +3,12 @@ const {
   commonExcludes,
 } = require('./rules/typescript/naming-convention')
 
-function createConfig({ allowedNames = [], project, enableTypeCheck } = {}) {
+function createConfig({
+  allowedNames = [],
+  project,
+  tsconfigRootDir,
+  enableTypeCheck,
+} = {}) {
   const namingConventionIgnoreRegEx = `^(${[
     ...commonExcludes,
     ...allowedNames,
@@ -37,7 +42,7 @@ function createConfig({ allowedNames = [], project, enableTypeCheck } = {}) {
                 ? {
                     extends:
                       'plugin:@typescript-eslint/recommended-requiring-type-checking',
-                    parserOptions: { project },
+                    parserOptions: { project, tsconfigRootDir },
                   }
                 : {}),
             }


### PR DESCRIPTION
## 설명

[Get started - Linting with Type Information](https://github.com/typescript-eslint/typescript-eslint/blob/master/docs/getting-started/linting/TYPED_LINTING.md)을 참고하여 타입 체크 규칙을 사용할 수 있는 옵션을 추가합니다.
`project`, `tsconfigRootDir`, `enableTypeCheck` 세 개의 파라미터를 모두 넣어줘야 정상적으로 타입 체크 규칙을 사용할 수 있습니다.