### PR TITLE
✨ eslint-typescript에서 추천하지 않는 import 규칙 비활성화

### DIFF
--- a/rules/typescript/index.js
+++ b/rules/typescript/index.js
@@ -59,5 +59,10 @@ module.exports = {
      */
     camelcase: 'off',
     '@typescript-eslint/naming-convention': getNamingConvention({ regex }),
+
+    'import/named': 'off',
+    'import/namespace': 'off',
+    'import/default': 'off',
+    'import/no-named-as-default-member': 'off',
   },
 }

--- a/test/__snapshots__/config.test.js.snap
+++ b/test/__snapshots__/config.test.js.snap
@@ -2698,7 +2698,7 @@ Object {
       "off",
     ],
     "import/default": Array [
-      "error",
+      "off",
     ],
     "import/export": Array [
       "error",
@@ -2710,7 +2710,7 @@ Object {
       "off",
     ],
     "import/namespace": Array [
-      "error",
+      "off",
     ],
     "import/newline-after-import": Array [
       "error",
@@ -2730,7 +2730,7 @@ Object {
       "warn",
     ],
     "import/no-named-as-default-member": Array [
-      "warn",
+      "off",
     ],
     "import/no-named-default": Array [
       "error",

--- a/test/__snapshots__/create-config.test.js.snap
+++ b/test/__snapshots__/create-config.test.js.snap
@@ -1796,7 +1796,7 @@ Object {
       "off",
     ],
     "import/default": Array [
-      "error",
+      "off",
     ],
     "import/export": Array [
       "error",
@@ -1808,7 +1808,7 @@ Object {
       "off",
     ],
     "import/namespace": Array [
-      "error",
+      "off",
     ],
     "import/newline-after-import": Array [
       "error",
@@ -1828,7 +1828,7 @@ Object {
       "warn",
     ],
     "import/no-named-as-default-member": Array [
-      "warn",
+      "off",
     ],
     "import/no-named-default": Array [
       "error",


### PR DESCRIPTION
typescript가 같은 역할을 하기 때문에 굳이 사용할 필요 없는 규칙을 비활성화합니다.

https://github.com/typescript-eslint/typescript-eslint/blob/master/docs/getting-started/linting/TROUBLESHOOTING.md#eslint-plugin-import

Resolve #152 