### PR TITLE
👥 코드 오너 팀원으로 설정

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @titicacadev/division-a
+* @zprime0920 @drakang4 @inbeom @polysiya


### PR DESCRIPTION
https://docs.google.com/spreadsheets/d/1XIh1VkPvFaeEztCQ8Q3ljv6_RFrEhvRblhA_M-wc91M/edit#gid=0

Branch Protection Rule의 "Require Codeowners approval" 옵션과 사용하면 명시한 팀원만 PR 리뷰를 할당할 수 있습니다.