### PR TITLE
README를 개선합니다.

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ module.exports = {
 #### babel을 사용하지 않는 프로젝트
 
 Babel을 사용하지 않는 프로젝트에서 Babel 설정을 찾을 수 없다는 파싱 에러가 발생합니다.
-다음을 설정을 추가해주세요.
+다음을 설정에 추가해주세요.
 
 ```js
 module.exports = {


### PR DESCRIPTION
- `createConfig` 함수의 type 파라미터가 필수인 것을 문서에 반영합니다.
- Javascript 예약어를 예시에서 사용하지 않습니다
- Babel을 사용하지 않는 프로젝트에 대한 안내를 문단으로 변경합니다.