### PR TITLE
[stylelint-config-triple] 1.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -628,9 +628,9 @@
       }
     },
     "node_modules/@csstools/css-tokenizer": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-2.0.2.tgz",
-      "integrity": "sha512-prUTipz0NZH7Lc5wyBUy93NFy3QYDMVEQgSeZzNdpMbKRd6V2bgRFyJ+O0S0Dw0MXWuE/H9WXlJk3kzMZRHZ/g==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-2.1.0.tgz",
+      "integrity": "sha512-dtqFyoJBHUxGi9zPZdpCKP1xk8tq6KPHJ/NY4qWXiYo6IcSGwzk3L8x2XzZbbyOyBs9xQARoGveU2AsgLj6D2A==",
       "engines": {
         "node": "^14 || ^16 || >=18"
       },
@@ -8275,9 +8275,9 @@
       }
     },
     "node_modules/known-css-properties": {
-      "version": "0.26.0",
-      "resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.26.0.tgz",
-      "integrity": "sha512-5FZRzrZzNTBruuurWpvZnvP9pum+fe0HcK8z/ooo+U+Hmp4vtbyp1/QDsqmufirXy4egGzbaH/y2uCZf+6W5Kg=="
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.27.0.tgz",
+      "integrity": "sha512-uMCj6+hZYDoffuvAJjFAPz56E9uoowFHmTkqRtRq5WyC5Q6Cu/fTZKNQpX/RbzChBYLLl3lo8CjFZBAZXq9qFg=="
     },
     "node_modules/language-subtag-registry": {
       "version": "0.3.22",
@@ -11173,9 +11173,9 @@
       }
     },
     "node_modules/postcss-styled-syntax": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/postcss-styled-syntax/-/postcss-styled-syntax-0.3.3.tgz",
-      "integrity": "sha512-TyoKQNPK4r2Ua7eeL2IdwXShIajO6svQMVtUSezxe1Ru3eNM1TJE+IxU82lTnUBX/sBQjY5TUtI69bZaoXjRpg==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/postcss-styled-syntax/-/postcss-styled-syntax-0.4.0.tgz",
+      "integrity": "sha512-LvG++K8LtIyX1Q1mNuZVQYmBo+SCwn90cEkMigo4/I0QwXrEiYt8nPeJ5rrI5Uuh+5w7hRfPyJKlvQdhVZBhUg==",
       "dependencies": {
         "@typescript-eslint/typescript-estree": "^5.47.0",
         "estree-walker": "^2.0.2"
@@ -12418,17 +12418,17 @@
       "integrity": "sha512-Dj1Okke1C3uKKwQcetra4jSuk0DqbzbYtXipzFlFMZtowbF1x7BKJwB9AayVMyFARvU8EDrZdcax4At/452cAg=="
     },
     "node_modules/stylelint": {
-      "version": "15.2.0",
-      "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-15.2.0.tgz",
-      "integrity": "sha512-wjg5OLn8zQwjlj5cYUgyQpMWKzct42AG5dYlqkHRJQJqsystFFn3onqEc263KH4xfEI0W3lZCnlIhFfS64uwSA==",
+      "version": "15.3.0",
+      "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-15.3.0.tgz",
+      "integrity": "sha512-9UYBYk7K9rtlKcTUDZrtntE840sZM00qyYBQHHe7tjwMNUsPsGvR6Fd43IxHEAhRrDLzpy3TVaHb6CReBB3eFg==",
       "dependencies": {
         "@csstools/css-parser-algorithms": "^2.0.1",
-        "@csstools/css-tokenizer": "^2.0.1",
+        "@csstools/css-tokenizer": "^2.1.0",
         "@csstools/media-query-list-parser": "^2.0.1",
         "@csstools/selector-specificity": "^2.1.1",
         "balanced-match": "^2.0.0",
         "colord": "^2.9.3",
-        "cosmiconfig": "^8.0.0",
+        "cosmiconfig": "^8.1.0",
         "css-functions-list": "^3.1.0",
         "css-tree": "^2.3.1",
         "debug": "^4.3.4",
@@ -12443,7 +12443,7 @@
         "import-lazy": "^4.0.0",
         "imurmurhash": "^0.1.4",
         "is-plain-object": "^5.0.0",
-        "known-css-properties": "^0.26.0",
+        "known-css-properties": "^0.27.0",
         "mathml-tag-names": "^2.1.3",
         "meow": "^9.0.0",
         "micromatch": "^4.0.5",
@@ -12459,7 +12459,7 @@
         "string-width": "^4.2.3",
         "strip-ansi": "^6.0.1",
         "style-search": "^0.1.0",
-        "supports-hyperlinks": "^2.3.0",
+        "supports-hyperlinks": "^3.0.0",
         "svg-tags": "^1.0.0",
         "table": "^6.8.1",
         "v8-compile-cache": "^2.3.0",
@@ -12474,6 +12474,14 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/stylelint"
+      }
+    },
+    "node_modules/stylelint-config-recommended": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-11.0.0.tgz",
+      "integrity": "sha512-SoGIHNI748OCZn6BxFYT83ytWoYETCINVHV3LKScVAWQQauWdvmdDqJC5YXWjpBbxg2E761Tg5aUGKLFOVhEkA==",
+      "peerDependencies": {
+        "stylelint": "^15.3.0"
       }
     },
     "node_modules/stylelint/node_modules/balanced-match": {
@@ -12556,15 +12564,15 @@
       }
     },
     "node_modules/supports-hyperlinks": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-2.3.0.tgz",
-      "integrity": "sha512-RpsAZlpWcDwOPQA22aCH4J0t7L8JmAvsCxfOSEwm7cQs3LshN36QaTkwd70DnBOXDWGssw2eUoc8CaRWT0XunA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-3.0.0.tgz",
+      "integrity": "sha512-QBDPHyPQDRTy9ku4URNGY5Lah8PAaXs6tAAwp55sL5WCsSW7GIfdf6W5ixfziW+t7wh3GVvHyHHyQ1ESsoRvaA==",
       "dependencies": {
         "has-flag": "^4.0.0",
         "supports-color": "^7.0.0"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=14.18"
       }
     },
     "node_modules/supports-preserve-symlinks-flag": {
@@ -13597,22 +13605,14 @@
       "version": "1.0.2",
       "license": "MIT",
       "dependencies": {
-        "postcss-styled-syntax": "^0.3.3",
-        "stylelint-config-recommended": "^10.0.1"
+        "postcss-styled-syntax": "^0.4.0",
+        "stylelint-config-recommended": "^11.0.0"
       },
       "devDependencies": {
-        "stylelint": "^15.2.0"
+        "stylelint": "^15.3.0"
       },
       "peerDependencies": {
-        "stylelint": "^15.0.0"
-      }
-    },
-    "packages/stylelint-config-triple/node_modules/stylelint-config-recommended": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-10.0.1.tgz",
-      "integrity": "sha512-TQ4xQ48tW4QSlODcti7pgSRqBZcUaBzuh0jPpfiMhwJKBPkqzTIAU+IrSWL/7BgXlOM90DjB7YaNgFpx8QWhuA==",
-      "peerDependencies": {
-        "stylelint": "^15.0.0"
+        "stylelint": "^15.3.0"
       }
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -13602,7 +13602,7 @@
     },
     "packages/stylelint-config-triple": {
       "name": "@titicaca/stylelint-config-triple",
-      "version": "1.0.2",
+      "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
         "postcss-styled-syntax": "^0.4.0",

--- a/packages/stylelint-config-triple/CHANGELOG.md
+++ b/packages/stylelint-config-triple/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v1.1.0
+
+- stylelint peer dependency 15.3.0 버전 이상으로 변경 [https://github.com/titicacadev/triple-config-kit/pull/218](#218)
+- css-in-js에서 `case`, `no-unknown` 규칙 다시 복구 [https://github.com/titicacadev/triple-config-kit/pull/218](#218)
+- `declaration-block-no-redundant-longhand-properties` 규칙이 `inset`을 ignore 하도록 변경 [https://github.com/titicacadev/triple-config-kit/pull/218](#218)
+
 ## v1.0.2
 
 - 컨픽들을 monorepo로 분리 [https://github.com/titicacadev/triple-config-kit/pull/211](#211)

--- a/packages/stylelint-config-triple/package.json
+++ b/packages/stylelint-config-triple/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@titicaca/stylelint-config-triple",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "description": "",
   "main": "stylelint.js",
   "files": [

--- a/packages/stylelint-config-triple/package.json
+++ b/packages/stylelint-config-triple/package.json
@@ -17,13 +17,13 @@
   },
   "homepage": "https://github.com/titicacadev/triple-config-kit",
   "dependencies": {
-    "postcss-styled-syntax": "^0.3.3",
-    "stylelint-config-recommended": "^10.0.1"
+    "postcss-styled-syntax": "^0.4.0",
+    "stylelint-config-recommended": "^11.0.0"
   },
   "devDependencies": {
-    "stylelint": "^15.2.0"
+    "stylelint": "^15.3.0"
   },
   "peerDependencies": {
-    "stylelint": "^15.0.0"
+    "stylelint": "^15.3.0"
   }
 }

--- a/packages/stylelint-config-triple/stylelint.js
+++ b/packages/stylelint-config-triple/stylelint.js
@@ -76,15 +76,9 @@ module.exports = {
       files: ['**/*.{js,ts,tsx}'],
       customSyntax: require('postcss-styled-syntax'),
       rules: {
-        // postcss-styled-syntax와 같이 사용하면 아직 버그가 있어서 일부 `no-empty`, `case`, 'no-unknown' 규칙을 끕니다.
+        // postcss-styled-syntax와 같이 사용하면 아직 버그가 있어서 일부 `no-empty` 규칙을 끕니다.
         'block-no-empty': null,
         'no-empty-source': null,
-
-        'function-name-case': null,
-        'value-keyword-case': null,
-
-        'annotation-no-unknown': null,
-        'function-no-unknown': null,
       },
     },
   ],

--- a/packages/stylelint-config-triple/stylelint.js
+++ b/packages/stylelint-config-triple/stylelint.js
@@ -65,7 +65,10 @@ module.exports = {
     'selector-attribute-quotes': 'always',
 
     // no-redundant
-    'declaration-block-no-redundant-longhand-properties': true,
+    'declaration-block-no-redundant-longhand-properties': [
+      true,
+      { ignoreShorthands: ['inset'] },
+    ],
     'shorthand-property-no-redundant-values': true,
 
     // white-inside


### PR DESCRIPTION
## stylelint-config-triple@1.1.0 변경사항

- stylelint peer dependency 15.3.0 버전 이상으로 변경
- css-in-js에서 `case`, `no-unknown` 규칙 다시 복구
	- 버그가 수정되었습니다. https://github.com/stylelint/stylelint/releases/tag/15.2.0
- `declaration-block-no-redundant-longhand-properties` 규칙이 `inset`을 ignore 하도록 변경
	- `inset`은 브라우저 호환성이 좋지 못해서 `top, left, right, bottom` 속성을 사용하는 것이 좋겠습니다. https://developer.mozilla.org/en-US/docs/Web/CSS/inset


