### PR TITLE
[prettier-config-triple] prettier 3 지원

### DIFF
--- a/packages/prettier-config-triple/package.json
+++ b/packages/prettier-config-triple/package.json
@@ -20,6 +20,6 @@
     "prettier": "^2.8.4"
   },
   "peerDependencies": {
-    "prettier": "^2.0.0"
+    "prettier": "^2.0.0 || ^3.0.0"
   }
 }


### PR DESCRIPTION
사용에 영향 없는 업데이트 인 것 같아서 prettier 3도 peer dependency로 지원합니다.

https://prettier.io/blog/2023/07/05/3.0.0.html