### PR TITLE
[stylelint-config-triple] css-in-js에서 media-query-no-invalid 끔

### DIFF
--- a/packages/stylelint-config-triple/CHANGELOG.md
+++ b/packages/stylelint-config-triple/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v1.2.1
+
+- css-in-js에서 media-query-no-invalid 끔
+
 ## v1.2.0
 
 - 의존성 업데이트 [https://github.com/titicacadev/triple-config-kit/pull/225](#225)

--- a/packages/stylelint-config-triple/package.json
+++ b/packages/stylelint-config-triple/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@titicaca/stylelint-config-triple",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Triple's Stylelint config, following our styleguide.",
   "license": "MIT",
   "main": "stylelint.js",

--- a/packages/stylelint-config-triple/stylelint.js
+++ b/packages/stylelint-config-triple/stylelint.js
@@ -82,6 +82,9 @@ module.exports = {
         // postcss-styled-syntax와 같이 사용하면 아직 버그가 있어서 일부 `no-empty` 규칙을 끕니다.
         'block-no-empty': null,
         'no-empty-source': null,
+
+        // css 표준 media query 명세가 css-in-js과 호환되지 않아서 끕니다.
+        'media-query-no-invalid': null,
       },
     },
   ],


### PR DESCRIPTION
- css-in-js에서 media-query-no-invalid 끔
	- css 표준 media query 명세가 css-in-js과 호환되지 않아서 끕니다.
- stylelint-config-triple 1.2.1 배포