### PR TITLE
[eslint-config-triple] curly 룰 추가

### DIFF
--- a/packages/eslint-config-triple/CHANGELOG.md
+++ b/packages/eslint-config-triple/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v5.1.1
+
+- curly 룰 추가 [https://github.com/titicacadev/triple-config-kit/pull/265](#265)
+
 ## v5.1.0
 
 - css prop 허용 [https://github.com/titicacadev/triple-config-kit/pull/220](#220)

--- a/packages/eslint-config-triple/frontend.js
+++ b/packages/eslint-config-triple/frontend.js
@@ -27,5 +27,6 @@ module.exports = {
         html: true,
       },
     ],
+    curly: ['error', 'all'],
   },
 }

--- a/packages/eslint-config-triple/package.json
+++ b/packages/eslint-config-triple/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@titicaca/eslint-config-triple",
-  "version": "5.1.0",
+  "version": "5.1.1",
   "description": "Triple's ESLint config, following our styleguide.",
   "license": "MIT",
   "main": "index.js",

--- a/packages/eslint-config-triple/prettier.js
+++ b/packages/eslint-config-triple/prettier.js
@@ -1,4 +1,10 @@
 /** @type {import('eslint').Linter.Config} */
 module.exports = {
   extends: ['prettier'],
+  rules: {
+    /**
+     * prettier에서 비활성화하지만 필요에 의해 다시 활성화하는 규칙
+     */
+    curly: ['error', 'all'],
+  },
 }

--- a/packages/eslint-config-triple/test/__snapshots__/config.test.js.snap
+++ b/packages/eslint-config-triple/test/__snapshots__/config.test.js.snap
@@ -24,6 +24,10 @@ exports[`eslint frontend config 1`] = `
   ],
   "reportUnusedDisableDirectives": undefined,
   "rules": {
+    "curly": [
+      "error",
+      "all",
+    ],
     "jsx-a11y/alt-text": [
       "error",
     ],


### PR DESCRIPTION
- 이전 PR( https://github.com/titicacadev/triple-config-kit/pull/46 )에서 추가되었언 curly 룰이 버전 업데이트가 되면서 제거되었던 것을 복구합니다. 
- `@titicaca/eslint-config-triple@5.1.1` 로 업데이트합니다.